### PR TITLE
Remove upcoming projects section from homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,28 +57,4 @@ import AnimatedIris from "../components/AnimatedIris.astro";
       </p>
     </div>
   </section>
-
-  <section class="section" aria-labelledby="coming">
-    <h2 id="coming">More projects launching soon</h2>
-    <div class="grid">
-      <div class="card">
-        <strong>Optical Studies</strong>
-        <p style="color: #c7cfdb">
-          Short films exploring lenses, motion, and AI-driven cinematography.
-        </p>
-      </div>
-      <div class="card">
-        <strong>Generative Design</strong>
-        <p style="color: #c7cfdb">
-          Visual systems that merge computation with hand-crafted aesthetics.
-        </p>
-      </div>
-      <div class="card">
-        <strong>Interactive Audio</strong>
-        <p style="color: #c7cfdb">
-          Procedural soundscapes and responsive voice for installations.
-        </p>
-      </div>
-    </div>
-  </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- remove the "More projects launching soon" section from the homepage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c03fa2408323990009c62f79ae81