### PR TITLE
Remove retired sections from home panels

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,18 +58,6 @@ import ThreeIrisBG from "../components/ThreeIrisBG.jsx";
           </a>
         </p>
       </div>
-      <div class="panel">
-        <strong>Optical Studies</strong>
-        <p style="color:#c7cfdb">Short films exploring lenses, motion, and AI-driven cinematography.</p>
-      </div>
-      <div class="panel">
-        <strong>Generative Design</strong>
-        <p style="color:#c7cfdb">Visual systems that merge computation with hand-crafted aesthetics.</p>
-      </div>
-      <div class="panel">
-        <strong>Interactive Audio</strong>
-        <p style="color:#c7cfdb">Procedural soundscapes and responsive voice for installations.</p>
-      </div>
     </div>
   </section>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -316,13 +316,7 @@ a:hover {
 .panels-grid {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-@media (max-width: 900px) {
-  .panels-grid {
-    grid-template-columns: 1fr;
-  }
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 /* Keep hero typography spacing tidy in this new layout */


### PR DESCRIPTION
## Summary
- remove the Optical Studies, Generative Design, and Interactive Audio panels from the homepage
- update the panels grid styling to auto-fit the remaining content so the layout stays balanced

## Testing
- npm run build *(fails: missing @astrojs/react dependency in the project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c65a60d08323a700d488d5726905